### PR TITLE
Fix Conv initialization and reduction stdout

### DIFF
--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -136,6 +136,17 @@ def test_reduce_max(params, device):
     )
 
 
+@pytest.mark.parametrize("device", _DEVICES, ids=["cpu", "cuda"])
+def test_single_axis_reductions_do_not_write_stdout(capsys, device):
+    A = nd.array(np.random.randn(2, 3, 4).astype("float32"), device=device)
+
+    A.sum(axis=1)
+    A.max(axis=2)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
 class _ShapeAndSlices(nd.NDArray):
     def __getitem__(self, idxs):
         idxs = tuple(

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -6,6 +6,7 @@ import tiny_pytorch.backend_ndarray.ndarray as nd
 import tiny_pytorch.nn as nn
 import tiny_pytorch.ops as ops
 from tiny_pytorch.tensor import Tensor
+from tiny_pytorch.vision.models import ResNet9
 
 np.random.seed(3)
 
@@ -1687,3 +1688,132 @@ def test_op_conv(Z_shape, W_shape, stride, padding, backward, device):
         assert err1 < 1e-2, "input grads match"
         assert err2 < 1e-2, "weight grads match"
     assert err3 < 1e-1, f"outputs match {y2}, {out2}"
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("device", _DEVICES, ids=["cpu", "cuda"])
+def test_nn_module_conv_forward_matches_torch(stride, bias, device):
+    np.random.seed(10 + stride + int(bias))
+
+    batch_size, in_channels, height, width = 2, 3, 8, 8
+    out_channels, kernel_size = 4, 3
+    x_data = np.random.randn(batch_size, in_channels, height, width).astype(
+        "float32"
+    )
+    weight_data = np.random.randn(
+        kernel_size, kernel_size, in_channels, out_channels
+    ).astype("float32")
+    bias_data = np.random.randn(out_channels).astype("float32")
+
+    conv = nn.Conv(
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=stride,
+        bias=bias,
+        device=device,
+    )
+    conv.weight.data = Tensor(weight_data, device=device)
+    if bias:
+        conv.bias.data = Tensor(bias_data, device=device)
+
+    x = Tensor(x_data, device=device)
+    out = conv(x)
+
+    torch_conv = torch.nn.Conv2d(
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=stride,
+        padding=(kernel_size - 1) // 2,
+        bias=bias,
+    )
+    with torch.no_grad():
+        torch_conv.weight.copy_(torch.tensor(weight_data).permute(3, 2, 0, 1))
+        if bias:
+            torch_conv.bias.copy_(torch.tensor(bias_data))
+    torch_out = torch_conv(torch.tensor(x_data))
+
+    assert conv.weight.shape == weight_data.shape
+    np.testing.assert_allclose(
+        out.numpy(), torch_out.detach().numpy(), rtol=1e-4, atol=1e-4
+    )
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("device", _DEVICES, ids=["cpu", "cuda"])
+def test_nn_module_conv_backward_matches_torch(stride, bias, device):
+    np.random.seed(100 + stride + int(bias))
+
+    batch_size, in_channels, height, width = 2, 2, 8, 8
+    out_channels, kernel_size = 3, 3
+    x_data = np.random.randn(batch_size, in_channels, height, width).astype(
+        "float32"
+    )
+    weight_data = np.random.randn(
+        kernel_size, kernel_size, in_channels, out_channels
+    ).astype("float32")
+    bias_data = np.random.randn(out_channels).astype("float32")
+
+    conv = nn.Conv(
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=stride,
+        bias=bias,
+        device=device,
+    )
+    conv.weight.data = Tensor(weight_data, device=device)
+    if bias:
+        conv.bias.data = Tensor(bias_data, device=device)
+
+    x = Tensor(x_data, device=device)
+    loss = conv(x).sum()
+    loss.backward()
+
+    torch_x = torch.tensor(x_data, requires_grad=True)
+    torch_conv = torch.nn.Conv2d(
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=stride,
+        padding=(kernel_size - 1) // 2,
+        bias=bias,
+    )
+    with torch.no_grad():
+        torch_conv.weight.copy_(torch.tensor(weight_data).permute(3, 2, 0, 1))
+        if bias:
+            torch_conv.bias.copy_(torch.tensor(bias_data))
+    torch_conv(torch_x).sum().backward()
+
+    np.testing.assert_allclose(
+        x.grad.numpy(), torch_x.grad.numpy(), rtol=1e-4, atol=1e-4
+    )
+    np.testing.assert_allclose(
+        conv.weight.grad.numpy(),
+        torch_conv.weight.grad.permute(2, 3, 1, 0).numpy(),
+        rtol=1e-4,
+        atol=1e-4,
+    )
+    if bias:
+        np.testing.assert_allclose(
+            conv.bias.grad.numpy(),
+            torch_conv.bias.grad.numpy(),
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+
+@pytest.mark.parametrize("device", _DEVICES, ids=["cpu", "cuda"])
+def test_resnet9_forward_backward_smoke(device):
+    np.random.seed(0)
+
+    model = ResNet9(device=device)
+    x = Tensor(np.random.randn(2, 3, 32, 32).astype("float32"), device=device)
+    out = model(x)
+
+    assert out.shape == (2, 10)
+    out.sum().backward()
+    assert x.grad is not None

--- a/tiny_pytorch/backend_ndarray/ndarray.py
+++ b/tiny_pytorch/backend_ndarray/ndarray.py
@@ -1074,7 +1074,6 @@ class NDArray:
                     f"Dimension out of range (expected to be in range of [-{self.ndim}, {self.ndim - 1}], but got {axis})"
                 )
             axis = axis + self.ndim if axis < 0 else axis
-            print(axis)
             view = self.permute(
                 tuple([a for a in range(self.ndim) if a != axis]) + (axis,)
             )

--- a/tiny_pytorch/init.py
+++ b/tiny_pytorch/init.py
@@ -441,7 +441,9 @@ def xavier_normal(fan_in, fan_out, gain=1.0, **kwargs):
     return randn(fan_in, fan_out, std=std, **kwargs)
 
 
-def kaiming_uniform(fan_in, fan_out, nonlinearity="relu", **kwargs):
+def kaiming_uniform(
+    fan_in, fan_out, shape=None, nonlinearity="relu", **kwargs
+):
     """Initialize weights using Kaiming/He uniform initialization.
 
     Parameters
@@ -450,6 +452,8 @@ def kaiming_uniform(fan_in, fan_out, nonlinearity="relu", **kwargs):
         Number of input features.
     fan_out : int
         Number of output features.
+    shape : tuple[int, ...], optional
+        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     nonlinearity : str, optional
         The non-linear function (or activation function) used in the model.
         Default is "relu".
@@ -481,7 +485,9 @@ def kaiming_uniform(fan_in, fan_out, nonlinearity="relu", **kwargs):
     """
     assert nonlinearity == "relu", "Only relu supported currently"
     bound = (6 / fan_in) ** 0.5
-    return rand(fan_in, fan_out, low=-bound, high=bound, **kwargs)
+    if shape is None:
+        shape = (fan_in, fan_out)
+    return rand(*shape, low=-bound, high=bound, **kwargs)
 
 
 def kaiming_normal(fan_in, fan_out, nonlinearity="relu", **kwargs):

--- a/tiny_pytorch/nn.py
+++ b/tiny_pytorch/nn.py
@@ -883,8 +883,10 @@ class BatchNorm2d(BatchNorm1d):
         # It is more efficient to use channel-last in the case
         # of batchnorm (similar to pytorch)
         b, c_in, h, w = x.shape
-        new_x = x.transpose((1, 2)).transpose((2, 3)).reshape((b, c_in, h, w))
-        y = super().forward(new_x).reshape((b, c_in, h, w))
+        new_x = (
+            x.transpose((1, 2)).transpose((2, 3)).reshape((b * h * w, c_in))
+        )
+        y = super().forward(new_x).reshape((b, h, w, c_in))
         return y.transpose((2, 3)).transpose((1, 2))
 
 


### PR DESCRIPTION
- Allow `kaiming_uniform` to accept an explicit tensor shape so `nn.Conv` can initialize 4-D kernel weights without passing unsupported kwargs to `rand`.

- Remove the stray debug print from single-axis NDArray reductions.

- Fix `BatchNorm2d` to normalize over `N * H * W` rows with `C` features so ResNet9 can run forward and backward.

- Add module-level Conv forward/backward tests, a ResNet9 smoke test, and a no-stdout reduction regression.

Tests:

- `TINY_PYTORCH_BACKEND=nd poetry run pytest -q`
- `poetry run pre-commit run --files tiny_pytorch/init.py tiny_pytorch/nn.py tiny_pytorch/backend_ndarray/ndarray.py tests/test_nn.py tests/test_ndarray.py`