### PR TITLE
Prepare 0.1.6 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tiny-pytorch"
-version = "0.1.5"
+version = "0.1.6"
 description = "Mini Deep Learning framework similar to PyTorch"
 authors = [
     {name = "Imad Dabbura", email = "imad.dabbura@hotmail.com"}

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ Setup script for tiny-pytorch with C++ and CUDA extensions.
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pybind11
@@ -210,6 +211,11 @@ def read_readme():
         return fh.read()
 
 
+def _read_version():
+    with Path("pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
 # Find CUDA installation
 cuda_home, cuda_include, cuda_lib = find_cuda()
 
@@ -257,7 +263,7 @@ else:
 if __name__ == "__main__":
     setup(
         name="tiny-pytorch",
-        version="0.0.4",
+        version=_read_version(),
         author="Imad Dabbura",
         author_email="imad.dabbura@hotmail.com",
         description="Mini Deep Learning framework similar to PyTorch",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,11 @@
+import tomllib
+from pathlib import Path
+
+import tiny_pytorch as tp
+
+
+def test_import_version_matches_project_version():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    project = tomllib.loads(pyproject.read_text())["project"]
+
+    assert tp.__version__ == project["version"]


### PR DESCRIPTION
- Bump project metadata to `0.1.6`.

- Read the `setup.py` version from `pyproject.toml` instead of carrying a stale literal.

- Add a packaging regression test that keeps import-time `__version__` aligned with project metadata.

Tests:

- `poetry run pytest tests/test_packaging.py -q`
- `poetry check --lock`
- `poetry run black --check setup.py tests/test_packaging.py`
- `poetry run isort --check-only setup.py tests/test_packaging.py`
- `poetry run flake8 setup.py tests/test_packaging.py`
- `poetry run python setup.py build_ext --inplace`
- `TINY_PYTORCH_BACKEND=nd poetry run pytest -q`

Note: `pre-commit run --files pyproject.toml setup.py tests/test_packaging.py` passed all hooks except `pyupgrade`, which failed with an internal Python 3.14 `TypeError`; the commit was created with only that hook skipped.