### PR TITLE
Fix documentation API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,21 @@ To get the very latest development version or if you plan to contribute, you can
 Here's a simple example of defining a model and running a forward/backward pass.
 
 ```python
+import numpy as np
+
 import tiny_pytorch as tp
 import tiny_pytorch.nn as nn
+import tiny_pytorch.optim as optim
+from tiny_pytorch import init
 
 
-# 1. Define a simple model
+# 1. Define a simple classifier
 class SimpleNet(nn.Module):
-    def __init__(self, in_features, out_features):
+    def __init__(self, in_features, num_classes):
+        super().__init__()
         self.fc1 = nn.Linear(in_features, 64)
         self.relu = nn.ReLU()
-        self.fc2 = nn.Linear(64, out_features)
+        self.fc2 = nn.Linear(64, num_classes)
 
     def forward(self, x):
         x = self.fc1(x)
@@ -122,22 +127,22 @@ class SimpleNet(nn.Module):
 
 
 # 2. Initialize model, optimizer, and loss function
-model = SimpleNet(in_features=10, out_features=1)
-optimizer = tp.optim.Adam(model.parameters(), lr=0.001)
-loss_fn = nn.MSELoss()
+model = SimpleNet(in_features=10, num_classes=3)
+optimizer = optim.Adam(model.parameters(), lr=0.001)
+loss_fn = nn.SoftmaxLoss()
 
 # 3. Create dummy data
-x_train = tp.randn(32, 10, requires_grad=True)
-y_true = tp.randn(32, 1)
+x_train = init.randn(32, 10)
+y_true = tp.Tensor(np.random.randint(0, 3, size=(32,)))
 
 # 4. Perform a single training step
-optimizer.zero_grad()  # Reset gradients
-y_pred = model(x_train)  # Forward pass
-loss = loss_fn(y_pred, y_true)  # Compute loss
+optimizer.reset_grad()  # Reset gradients
+logits = model(x_train)  # Forward pass
+loss = loss_fn(logits, y_true)  # Compute loss
 loss.backward()  # Backward pass (autograd)
 optimizer.step()  # Update weights
 
-print(f"Loss: {loss.item():.4f}")
+print(f"Loss: {loss.numpy().item():.4f}")
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,16 +104,21 @@ To get the very latest development version or if you plan to contribute, you can
 Here's a simple example of defining a model and running a forward/backward pass.
 
 ```python
+import numpy as np
+
 import tiny_pytorch as tp
 import tiny_pytorch.nn as nn
+import tiny_pytorch.optim as optim
+from tiny_pytorch import init
 
 
-# 1. Define a simple model
+# 1. Define a simple classifier
 class SimpleNet(nn.Module):
-    def __init__(self, in_features, out_features):
+    def __init__(self, in_features, num_classes):
+        super().__init__()
         self.fc1 = nn.Linear(in_features, 64)
         self.relu = nn.ReLU()
-        self.fc2 = nn.Linear(64, out_features)
+        self.fc2 = nn.Linear(64, num_classes)
 
     def forward(self, x):
         x = self.fc1(x)
@@ -122,22 +127,22 @@ class SimpleNet(nn.Module):
 
 
 # 2. Initialize model, optimizer, and loss function
-model = SimpleNet(in_features=10, out_features=1)
-optimizer = tp.optim.Adam(model.parameters(), lr=0.001)
-loss_fn = nn.MSELoss()
+model = SimpleNet(in_features=10, num_classes=3)
+optimizer = optim.Adam(model.parameters(), lr=0.001)
+loss_fn = nn.SoftmaxLoss()
 
 # 3. Create dummy data
-x_train = tp.randn(32, 10, requires_grad=True)
-y_true = tp.randn(32, 1)
+x_train = init.randn(32, 10)
+y_true = tp.Tensor(np.random.randint(0, 3, size=(32,)))
 
 # 4. Perform a single training step
-optimizer.zero_grad()  # Reset gradients
-y_pred = model(x_train)  # Forward pass
-loss = loss_fn(y_pred, y_true)  # Compute loss
+optimizer.reset_grad()  # Reset gradients
+logits = model(x_train)  # Forward pass
+loss = loss_fn(logits, y_true)  # Compute loss
 loss.backward()  # Backward pass (autograd)
 optimizer.step()  # Update weights
 
-print(f"Loss: {loss.item():.4f}")
+print(f"Loss: {loss.numpy().item():.4f}")
 ```
 
 ---

--- a/docs/nn.md
+++ b/docs/nn.md
@@ -3,15 +3,15 @@
 Neural network layers and loss functions built on top of the `Tensor` and `ops` modules. Follows the `Module` pattern familiar from PyTorch — subclass `Module`, implement `forward`, and compose layers freely.
 
 ```python
-import tiny_pytorch as tp
 import tiny_pytorch.nn as nn
+from tiny_pytorch import init
 
 model = nn.Sequential(
     nn.Linear(784, 128),
     nn.ReLU(),
     nn.Linear(128, 10),
 )
-x = tp.randn(32, 784)
+x = init.randn(32, 784)
 out = model(x)  # (32, 10)
 ```
 

--- a/docs/optim.md
+++ b/docs/optim.md
@@ -3,14 +3,15 @@
 Parameter update algorithms for training neural networks. Each optimizer takes a list of model parameters and updates them in-place based on their gradients.
 
 ```python
-import tiny_pytorch as tp
 import tiny_pytorch.nn as nn
+import tiny_pytorch.optim as optim
+from tiny_pytorch import init
 
 model = nn.Linear(10, 1)
-optimizer = tp.optim.Adam(model.parameters(), lr=0.001)
+optimizer = optim.Adam(model.parameters(), lr=0.001)
 
-optimizer.zero_grad()
-loss = model(tp.randn(4, 10)).sum()
+optimizer.reset_grad()
+loss = model(init.randn(4, 10)).sum()
 loss.backward()
 optimizer.step()
 ```

--- a/tiny_pytorch/nn.py
+++ b/tiny_pytorch/nn.py
@@ -85,30 +85,31 @@ containers provide convenient ways to combine multiple modules.
 
 Examples
 --------
->>> import tiny_pytorch as tp
+>>> import tiny_pytorch.nn as nn
+>>> from tiny_pytorch import init
 >>>
 >>> # Create a simple feedforward network
->>> model = tp.nn.Sequential(
-...     tp.nn.Linear(784, 128),
-...     tp.nn.ReLU(),
-...     tp.nn.Dropout(0.5),
-...     tp.nn.Linear(128, 10)
+>>> model = nn.Sequential(
+...     nn.Linear(784, 128),
+...     nn.ReLU(),
+...     nn.Dropout(0.5),
+...     nn.Linear(128, 10)
 ... )
 >>>
 >>> # Create a convolutional network
->>> conv_model = tp.nn.Sequential(
-...     tp.nn.Conv(3, 64, kernel_size=3),
-...     tp.nn.BatchNorm2d(64),
-...     tp.nn.ReLU(),
-...     tp.nn.Flatten(),
-...     tp.nn.Linear(64 * 28 * 28, 10)
+>>> conv_model = nn.Sequential(
+...     nn.Conv(3, 64, kernel_size=3),
+...     nn.BatchNorm2d(64),
+...     nn.ReLU(),
+...     nn.Flatten(),
+...     nn.Linear(64 * 28 * 28, 10)
 ... )
 >>>
 >>> # Create an RNN for sequence processing
->>> rnn = tp.nn.RNN(input_size=100, hidden_size=64, num_layers=2)
+>>> rnn = nn.RNN(input_size=100, hidden_size=64, num_layers=2)
 >>>
 >>> # Use the model
->>> x = tp.Tensor.randn(32, 784)  # batch_size=32, features=784
+>>> x = init.randn(32, 784)  # batch_size=32, features=784
 >>> output = model(x)  # Forward pass
 """
 
@@ -836,7 +837,8 @@ class BatchNorm2d(BatchNorm1d):
     Examples
     --------
     >>> bn = BatchNorm2d(64)
-    >>> x = Tensor.randn(32, 64, 28, 28)  # batch_size=32, channels=64, height=28, width=28
+    >>> from tiny_pytorch import init
+    >>> x = init.randn(32, 64, 28, 28)  # batch_size=32, channels=64, height=28, width=28
     >>> output = bn(x)  # shape: (32, 64, 28, 28)
     """
 
@@ -939,7 +941,8 @@ class ConvBN(Module):
     Examples
     --------
     >>> convbn = ConvBN(3, 64, kernel_size=3, stride=1)
-    >>> x = Tensor.randn(32, 3, 28, 28)  # batch_size=32, channels=3, height=28, width=28
+    >>> from tiny_pytorch import init
+    >>> x = init.randn(32, 3, 28, 28)  # batch_size=32, channels=3, height=28, width=28
     >>> output = convbn(x)  # shape: (32, 64, 28, 28)
     """
 
@@ -1834,7 +1837,8 @@ class Conv(Module):
     Examples
     --------
     >>> conv = Conv(3, 64, kernel_size=3, stride=1)
-    >>> x = Tensor.randn(1, 3, 32, 32)  # batch_size=1, channels=3, height=32, width=32
+    >>> from tiny_pytorch import init
+    >>> x = init.randn(1, 3, 32, 32)  # batch_size=1, channels=3, height=32, width=32
     >>> output = conv(x)  # shape: (1, 64, 32, 32)
     """
 

--- a/tiny_pytorch/ops.py
+++ b/tiny_pytorch/ops.py
@@ -1706,8 +1706,9 @@ def conv(a: Tensor, b: Tensor, stride: int = 1, padding: int = 1) -> Tensor:
 
     Examples
     --------
-    >>> x = Tensor.randn(1, 32, 32, 3)  # 1 batch, 32x32 image, 3 channels
-    >>> kernel = Tensor.randn(3, 3, 3, 16)  # 3x3 kernel, 3 input channels, 16 output channels
+    >>> from tiny_pytorch import init
+    >>> x = init.randn(1, 32, 32, 3)  # 1 batch, 32x32 image, 3 channels
+    >>> kernel = init.randn(3, 3, 3, 16)  # 3x3 kernel, 3 input channels, 16 output channels
     >>> result = conv(x, kernel, stride=1, padding=1)
     >>> result.shape  # (1, 32, 32, 16)
     (1, 32, 32, 16)

--- a/tiny_pytorch/optim.py
+++ b/tiny_pytorch/optim.py
@@ -51,17 +51,18 @@ making them easy to use in training loops.
 
 Examples
 --------
->>> import tiny_pytorch as tp
+>>> import tiny_pytorch.nn as nn
+>>> import tiny_pytorch.optim as optim
 >>>
 >>> # Create a simple model
->>> model = tp.nn.Sequential(
-...     tp.nn.Linear(784, 128),
-...     tp.nn.ReLU(),
-...     tp.nn.Linear(128, 10)
+>>> model = nn.Sequential(
+...     nn.Linear(784, 128),
+...     nn.ReLU(),
+...     nn.Linear(128, 10)
 ... )
 >>>
 >>> # Create an optimizer
->>> optimizer = tp.optim.SGD(
+>>> optimizer = optim.SGD(
 ...     model.parameters(), lr=0.01, momentum=0.9, weight_decay=1e-4
 ... )
 >>>
@@ -70,7 +71,7 @@ Examples
 ...     for batch_x, batch_y in dataloader:
 ...         # Forward pass
 ...         output = model(batch_x)
-...         loss = tp.nn.SoftmaxLoss()(output, batch_y)
+...         loss = nn.SoftmaxLoss()(output, batch_y)
 ...
 ...         # Backward pass
 ...         loss.backward()
@@ -80,7 +81,7 @@ Examples
 ...         optimizer.reset_grad()
 >>>
 >>> # Using Adam optimizer
->>> adam_optimizer = tp.optim.Adam(
+>>> adam_optimizer = optim.Adam(
 ...     model.parameters(), lr=0.001, beta1=0.9, beta2=0.999
 ... )
 


### PR DESCRIPTION
## What changed

- Replaced the README and docs quick-start with a runnable classification example using the real Tiny-PyTorch API.

- Updated docs snippets to import `nn` and `optim` modules directly instead of using missing `tp.nn` and `tp.optim` attributes.

- Updated generated docstring examples to use `init.randn` instead of nonexistent `Tensor.randn` or `tp.randn` helpers.

## Why

- The old examples advertised APIs that are not exposed by the package and would fail for users copying them.