### PR TITLE
Improve topo sort and initializer shapes

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from tiny_pytorch import init
 
@@ -81,3 +82,28 @@ def test_init_xavier_normal():
         rtol=1e-4,
         atol=1e-4,
     )
+
+
+@pytest.mark.parametrize(
+    "initializer",
+    [
+        init.xavier_uniform,
+        init.xavier_normal,
+        init.kaiming_uniform,
+        init.kaiming_normal,
+    ],
+)
+def test_fan_initializers_accept_explicit_shape(initializer):
+    np.random.seed(42)
+
+    tensor = initializer(6, 12, shape=(2, 3, 4))
+
+    assert tensor.shape == (2, 3, 4)
+
+
+def test_kaiming_uniform_preserves_positional_nonlinearity():
+    np.random.seed(42)
+
+    tensor = init.kaiming_uniform(6, 12, "relu")
+
+    assert tensor.shape == (6, 12)

--- a/tiny_pytorch/init.py
+++ b/tiny_pytorch/init.py
@@ -357,7 +357,7 @@ def ones_like(array, *, device=None, requires_grad=False):
     )
 
 
-def xavier_uniform(fan_in, fan_out, gain=1.0, **kwargs):
+def xavier_uniform(fan_in, fan_out, gain=1.0, *, shape=None, **kwargs):
     """Initialize weights using Xavier/Glorot uniform initialization.
 
     Parameters
@@ -369,6 +369,8 @@ def xavier_uniform(fan_in, fan_out, gain=1.0, **kwargs):
     gain : float, optional
         Scaling factor for the bounds of the uniform distribution.
         Default is 1.0.
+    shape : tuple[int, ...], optional
+        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     **kwargs
         Additional arguments passed to rand().
 
@@ -393,13 +395,16 @@ def xavier_uniform(fan_in, fan_out, gain=1.0, **kwargs):
     --------
     >>> xavier_uniform(10, 5)  # 10x5 tensor with Xavier initialization
     >>> xavier_uniform(20, 10, gain=2.0)  # Scaled initialization
+    >>> xavier_uniform(9, 16, shape=(3, 3, 1, 16))  # Conv-shaped weights
     >>> xavier_uniform(5, 5, device=gpu())  # Initialize on GPU
     """
     a = gain * ((6 / (fan_in + fan_out)) ** 0.5)
-    return rand(fan_in, fan_out, low=-a, high=a, **kwargs)
+    if shape is None:
+        shape = (fan_in, fan_out)
+    return rand(*shape, low=-a, high=a, **kwargs)
 
 
-def xavier_normal(fan_in, fan_out, gain=1.0, **kwargs):
+def xavier_normal(fan_in, fan_out, gain=1.0, *, shape=None, **kwargs):
     """Initialize weights using Xavier/Glorot normal initialization.
 
     Parameters
@@ -411,6 +416,8 @@ def xavier_normal(fan_in, fan_out, gain=1.0, **kwargs):
     gain : float, optional
         Scaling factor for the standard deviation of the normal distribution.
         Default is 1.0.
+    shape : tuple[int, ...], optional
+        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     **kwargs
         Additional arguments passed to randn().
 
@@ -435,14 +442,17 @@ def xavier_normal(fan_in, fan_out, gain=1.0, **kwargs):
     --------
     >>> xavier_normal(10, 5)  # 10x5 tensor with Xavier initialization
     >>> xavier_normal(20, 10, gain=2.0)  # Scaled initialization
+    >>> xavier_normal(9, 16, shape=(3, 3, 1, 16))  # Conv-shaped weights
     >>> xavier_normal(5, 5, device=gpu())  # Initialize on GPU
     """
     std = gain * ((2 / (fan_in + fan_out)) ** 0.5)
-    return randn(fan_in, fan_out, std=std, **kwargs)
+    if shape is None:
+        shape = (fan_in, fan_out)
+    return randn(*shape, std=std, **kwargs)
 
 
 def kaiming_uniform(
-    fan_in, fan_out, shape=None, nonlinearity="relu", **kwargs
+    fan_in, fan_out, nonlinearity="relu", *, shape=None, **kwargs
 ):
     """Initialize weights using Kaiming/He uniform initialization.
 
@@ -452,11 +462,11 @@ def kaiming_uniform(
         Number of input features.
     fan_out : int
         Number of output features.
-    shape : tuple[int, ...], optional
-        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     nonlinearity : str, optional
         The non-linear function (or activation function) used in the model.
         Default is "relu".
+    shape : tuple[int, ...], optional
+        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     **kwargs
         Additional arguments passed to rand().
 
@@ -480,7 +490,8 @@ def kaiming_uniform(
     Examples
     --------
     >>> kaiming_uniform(10, 5)  # 10x5 tensor with Kaiming initialization
-    >>> kaiming_uniform(20, 10, nonlinearity="tanh")  # Initialize for tanh
+    >>> kaiming_uniform(20, 10, nonlinearity="relu")  # Explicit ReLU initialization
+    >>> kaiming_uniform(9, 16, shape=(3, 3, 1, 16))  # Conv-shaped weights
     >>> kaiming_uniform(5, 5, device=gpu())  # Initialize on GPU
     """
     assert nonlinearity == "relu", "Only relu supported currently"
@@ -490,7 +501,9 @@ def kaiming_uniform(
     return rand(*shape, low=-bound, high=bound, **kwargs)
 
 
-def kaiming_normal(fan_in, fan_out, nonlinearity="relu", **kwargs):
+def kaiming_normal(
+    fan_in, fan_out, nonlinearity="relu", *, shape=None, **kwargs
+):
     """
     Initialize weights using Kaiming/He normal initialization.
 
@@ -503,6 +516,8 @@ def kaiming_normal(fan_in, fan_out, nonlinearity="relu", **kwargs):
     nonlinearity : str, optional
         The non-linear function (or activation function) used in the model.
         Default is "relu".
+    shape : tuple[int, ...], optional
+        Shape of the initialized tensor. Defaults to ``(fan_in, fan_out)``.
     **kwargs
         Additional arguments passed to randn().
 
@@ -525,4 +540,6 @@ def kaiming_normal(fan_in, fan_out, nonlinearity="relu", **kwargs):
     """
     assert nonlinearity == "relu", "Only relu supported currently"
     std = (2 / fan_in) ** 0.5
-    return randn(fan_in, fan_out, std=std, **kwargs)
+    if shape is None:
+        shape = (fan_in, fan_out)
+    return randn(*shape, std=std, **kwargs)

--- a/tiny_pytorch/tensor.py
+++ b/tiny_pytorch/tensor.py
@@ -739,11 +739,10 @@ def find_topo_sort(node_list: list[Tensor]) -> list[Tensor]:
     list[Tensor]
         Topologically sorted list of tensors.
     """
-    visited = []
+    visited = set()
     topo_list = []
     for output_node in node_list:
-        for input_node in _topo_sort_dfs(output_node, visited, topo_list):
-            topo_list.append(input_node)
+        _topo_sort_dfs(output_node, visited, topo_list)
     return topo_list
 
 
@@ -754,19 +753,14 @@ def _topo_sort_dfs(node, visited, topo_list):
     ----------
     node : Tensor
         Current node in the DFS traversal.
-    visited : list[Tensor]
-        List of already visited nodes.
+    visited : set[Tensor]
+        Set of already visited nodes.
     topo_list : list[Tensor]
         List to collect nodes in topological order.
-
-    Yields
-    ------
-    Tensor
-        Nodes in post-order DFS traversal.
     """
+    if node in visited:
+        return
+    visited.add(node)
     for input_node in node.inputs:
-        if input_node not in visited:
-            yield from _topo_sort_dfs(input_node, visited, topo_list)
-    visited.append(node)
-    if node not in topo_list:
-        yield node
+        _topo_sort_dfs(input_node, visited, topo_list)
+    topo_list.append(node)


### PR DESCRIPTION
## What changed

- Replaced list-based topo-sort visited tracking with a set-backed recursive post-order traversal.

- Added `shape=` support to Xavier and Kaiming normal/uniform initializers so fan-based bounds can be used with non-matrix weights.

- Added initializer regression tests for explicit shapes and `kaiming_uniform(…, "relu")` positional compatibility.

## Why

- The old topo-sort implementation used repeated list membership checks in graph traversal.

- `kaiming_uniform` supported conv-shaped weights after PR1, but the related initializers still rejected the same `shape=` pattern.